### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -28,7 +28,7 @@ class DailyTask(Task):
     target_time: str
 
     def __init__(
-            self, target_time: str, function: Callable, args: Dict | None = None
+        self, target_time: str, function: Callable, args: Dict | None = None
     ) -> None:
         self.target_time = target_time
         super().__init__(function, args)
@@ -42,10 +42,10 @@ class SingularTask(Task):
     target_time: datetime.datetime
 
     def __init__(
-            self,
-            target_time: datetime.datetime,
-            function: Callable,
-            args: Dict | None = None,
+        self,
+        target_time: datetime.datetime,
+        function: Callable,
+        args: Dict | None = None,
     ) -> None:
         self.target_time = target_time.astimezone(tz.tzlocal())
         super().__init__(function, args)
@@ -68,7 +68,7 @@ class TimeScheduler:
     def start(self):
         scheduler = BackgroundScheduler()
         scheduler.start()
-        logging.getLogger('apscheduler.scheduler').setLevel('WARNING')
+        logging.getLogger("apscheduler.scheduler").setLevel("WARNING")
 
         for task in self.task_list:
             trigger = task.create_trigger()


### PR DESCRIPTION
There appear to be some python formatting errors in 7751517c473c26b7ec5b804f3dbd18b518ddebc3. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.